### PR TITLE
Add support to getExchangeRate using EUR

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can install this module by using npm [NPM](https://npmjs.org/package/ecb-exc
 
 The first step is to include the library on you app by doing:
 
-    var currencyConverter = require('currencyConverter');
+    var currencyConverter = require('ecb-exchange-rates');
 
 If we need to convert a given value, then we create this settings object:
 

--- a/currencyConverter.js
+++ b/currencyConverter.js
@@ -47,7 +47,7 @@ module.exports = {
          var rate = eval('item.$').rate;
          self.currenciesMap.push({ currency: currency, rate: rate });
       });
-
+      self.currenciesMap.push({ currency: 'EUR', rate: 1 });
       self.executeCallback();
     },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecb-exchange-rates",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "European Central Bank Exchange Rates API client module for nodejs",
   "main": "currencyConverter.js",
   "scripts": {


### PR DESCRIPTION
Also fix a readme typo

I only tested with my use case. Let me know if you didn't support this on purpose : 

> var settings = {};
> settings.fromCurrency = 'EUR';
> settings.toCurrency = 'CNY';
> currencyConverter.getExchangeRate(settings , function(data){
>     logger.info(JSON.stringify(data));
>     return next(null, data.exchangeRate);
> });
