### PR TITLE
Switch ECB endpoint to new HTTPS URL

### DIFF
--- a/currencyConverter.js
+++ b/currencyConverter.js
@@ -7,7 +7,7 @@ var path = require('path');
 module.exports = {
 
     settings: {
-      url: "http://www.ecb.int/stats/eurofxref/eurofxref-daily.xml"
+      url: "https://www.ecb.int/stats/eurofxref/eurofxref-daily.xml"
     },
 
     baseCurrency: "EUR",

--- a/currencyConverter.js
+++ b/currencyConverter.js
@@ -7,7 +7,7 @@ var path = require('path');
 module.exports = {
 
     settings: {
-      url: "https://www.ecb.int/stats/eurofxref/eurofxref-daily.xml"
+      url: "https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml"
     },
 
     baseCurrency: "EUR",


### PR DESCRIPTION
The original URL has now moved. See below for a curl trace:

```
curl -v https://www.ecb.int/stats/eurofxref/eurofxref-daily.xml
* Host www.ecb.int:443 was resolved.
* IPv6: (none)
* IPv4: 80.90.16.91
*   Trying 80.90.16.91:443...
* Connected to www.ecb.int (80.90.16.91) port 443
* ALPN: curl offers h2,http/1.1
* (304) (OUT), TLS handshake, Client hello (1):
*  CAfile: /etc/ssl/cert.pem
*  CApath: none
* (304) (IN), TLS handshake, Server hello (2):
* (304) (IN), TLS handshake, Unknown (8):
* (304) (IN), TLS handshake, Certificate (11):
* (304) (IN), TLS handshake, CERT verify (15):
* (304) (IN), TLS handshake, Finished (20):
* (304) (OUT), TLS handshake, Finished (20):
* SSL connection using TLSv1.3 / AEAD-AES256-GCM-SHA384 / [blank] / UNDEF
* ALPN: server accepted http/1.1
* Server certificate:
*  subject: C=DE; L=Frankfurt am Main; O=European Central Bank; CN=www.ecb.europa.eu
*  start date: Sep 30 10:05:22 2024 GMT
*  expire date: Oct 29 10:05:20 2025 GMT
*  subjectAltName: host "www.ecb.int" matched cert's "www.ecb.int"
*  issuer: C=US; O=Entrust, Inc.; OU=See www.entrust.net/legal-terms; OU=(c) 2016 Entrust, Inc. - for authorized use only; CN=Entrust Certification Authority - L1F
*  SSL certificate verify ok.
* using HTTP/1.x
> GET /stats/eurofxref/eurofxref-daily.xml HTTP/1.1
> Host: www.ecb.int
> User-Agent: curl/8.7.1
> Accept: */*
>
* Request completely sent off
< HTTP/1.1 301 Moved Permanently
< Server: myracloud
< Date: Sun, 20 Oct 2024 09:46:27 GMT
< Content-Type: text/html
< Content-Length: 161
< Connection: keep-alive
< Location: https://www.ecb.europa.eu/stats/eurofxref/eurofxref-daily.xml
<
<html>
<head><title>301 Moved Permanently</title></head>
<body>
<center><h1>301 Moved Permanently</h1></center>
<hr><center>Myra</center>
</body>
</html>
* Connection #0 to host www.ecb.int left intact
```